### PR TITLE
rack-corsを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem 'rack-cors'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.7)
+    rack-cors (2.0.2)
+      rack (>= 2.0.0)
     rack-session (2.0.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)
@@ -220,6 +222,7 @@ DEPENDENCIES
   jbuilder
   pg (~> 1.1)
   puma (>= 5.0)
+  rack-cors
   rails (~> 7.1.3, >= 7.1.3.4)
   sprockets-rails
   stimulus-rails

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,6 @@
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins '*'
+    resource '*', headers: :any, methods: [:get, :post, :patch, :put]
+  end
+end


### PR DESCRIPTION
## 変更内容
close #3 

- gem 'rack-cors'を追加
- 設定ファイルを追加
  - 簡易的に動作確認をすることが目的なので、許可するOriginは任意に設定

## 動作確認
rack-corsを設定後、サーバーを再度立ち上げるために`docker compose up --build`

```
mtateno@tatenonoMBP tentative-hp-backend % curl -H "Origin: http://example.com" -H "Access-Control-Request-Method: GET" -X OPTIONS http://localhost:3000 -v              
* Host localhost:3000 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:3000...
* Connected to localhost (::1) port 3000
> OPTIONS / HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/8.6.0
> Accept: */*
> Origin: http://example.com
> Access-Control-Request-Method: GET
> 
< HTTP/1.1 200 OK
< access-control-allow-origin: *
< access-control-allow-methods: GET, POST, PATCH, PUT
< access-control-expose-headers: 
< access-control-max-age: 7200
< Content-Length: 0
< 
* Connection #0 to host localhost left intact
```